### PR TITLE
Implement save/load for cards

### DIFF
--- a/Card.vb
+++ b/Card.vb
@@ -1,10 +1,24 @@
-﻿Public Class Card
+Public Class Card
     Private Sub TextBox3_TextChanged(sender As Object, e As EventArgs) Handles TextBox3.TextChanged
 
     End Sub
 
     Private Sub Card_Load(sender As Object, e As EventArgs) Handles MyBase.Load
 
+    End Sub
+
+    Public Function ToCardData() As CardData
+        Return New CardData With {
+            .Title = TextBox1.Text,
+            .Description = RichTextBox1.Text,
+            .Deck = DropDownButton1.Text
+        }
+    End Function
+
+    Public Sub FromCardData(data As CardData)
+        TextBox1.Text = data.Title
+        RichTextBox1.Text = data.Description
+        DropDownButton1.Text = data.Deck
     End Sub
 
 End Class

--- a/CardData.vb
+++ b/CardData.vb
@@ -1,0 +1,5 @@
+Public Class CardData
+    Public Property Title As String
+    Public Property Description As String
+    Public Property Deck As String
+End Class

--- a/WorldNexus Editor.vb
+++ b/WorldNexus Editor.vb
@@ -1,5 +1,7 @@
-﻿Imports System.ComponentModel
+Imports System.ComponentModel
 Imports System.Text
+Imports System.Text.Json
+Imports System.IO
 Imports DevExpress.XtraBars
 Imports DevExpress.XtraBars.Ribbon
 
@@ -31,7 +33,11 @@ Partial Public Class WorldNexusEditor
     End Sub
 
     Private Sub BackstageViewButtonItem1_ItemClick(sender As Object, e As DevExpress.XtraBars.Ribbon.BackstageViewItemEventArgs) Handles BackstageViewButtonItem1.ItemClick
-
+        Dim dialog As New DevExpress.XtraEditors.XtraSaveFileDialog()
+        dialog.Filter = "Story World (*.storyworld)|*.storyworld"
+        If dialog.ShowDialog() = DialogResult.OK Then
+            SaveCards(dialog.FileName)
+        End If
     End Sub
 
     Private Sub BackstageViewButtonItem2_ItemClick(sender As Object, e As BackstageViewItemEventArgs) Handles BackstageViewButtonItem2.ItemClick
@@ -43,7 +49,43 @@ Partial Public Class WorldNexusEditor
     End Sub
 
     Private Sub XtraOpenFileDialog1_FileOk(sender As Object, e As CancelEventArgs)
+        LoadCards(XtraOpenFileDialog1.FileName)
+    End Sub
 
+    Private Sub SaveCards(path As String)
+        Dim list As New List(Of CardData)()
+        For Each ctrl As Control In StackPanel1.Controls
+            If TypeOf ctrl Is Card Then
+                Dim c As Card = CType(ctrl, Card)
+                list.Add(c.ToCardData())
+            End If
+        Next
+        Dim json As String = JsonSerializer.Serialize(list, New JsonSerializerOptions With {.WriteIndented = True})
+        File.WriteAllText(path, json)
+    End Sub
+
+    Private Sub LoadCards(path As String)
+        If Not File.Exists(path) Then Return
+        Dim json As String = File.ReadAllText(path)
+        Dim list As List(Of CardData) = JsonSerializer.Deserialize(Of List(Of CardData))(json)
+        If list Is Nothing Then Return
+        Dim toRemove = New List(Of Control)()
+        For Each ctrl As Control In StackPanel1.Controls
+            If TypeOf ctrl Is Card Then
+                toRemove.Add(ctrl)
+            End If
+        Next
+        For Each ctrl As Control In toRemove
+            StackPanel1.Controls.Remove(ctrl)
+            ctrl.Dispose()
+        Next
+        For Each data As CardData In list
+            Dim c As New Card()
+            c.FromCardData(data)
+            StackPanel1.Controls.Add(c)
+            c.Location = New Point(10, 10)
+            c.Size = New Size(200, 100)
+        Next
     End Sub
 
 End Class


### PR DESCRIPTION
## Summary
- add `CardData` class for serialization
- allow cards to convert to/from `CardData`
- implement storyworld save/load in the editor

## Testing
- `dotnet build -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ce270008c8329afd07c3d767cead4